### PR TITLE
Update OSF dependent repos to latest stable points

### DIFF
--- a/Wiwynn/deltalake/download_and_build.sh
+++ b/Wiwynn/deltalake/download_and_build.sh
@@ -2,7 +2,6 @@
 
 scriptdir="$(realpath "$(dirname "$0")")"
 osf_builder_hash="11d894bfe70e9b371c7dba9a02c6ccb24bd0c524"
-fsp_hash="0e18518131e7ecfeeb4afeab306121ca554c5054"
 edk2_non_osi_hash="61662e8596dd9a64e3372f9a3ba6622d2628607c"
 
 patches="${scriptdir}/src/*.patch"
@@ -25,11 +24,6 @@ download_intel_blobs()
   cd edk2-non-osi
   git checkout $edk2_non_osi_hash
   cd ..
-  git clone https://github.com/intel/FSP.git
-  cd FSP
-  git checkout $fsp_hash
-  mkdir CPX-FSP-split
-  python Tools/SplitFspBin.py split -f CedarIslandFspBinPkg/Fsp.fd -o CPX-FSP-split
   cd $scriptdir
 }
 
@@ -42,9 +36,6 @@ cd osf-builder
 git checkout $osf_builder_hash
 # Apply patches that add Delta Lake files to osf-builder
 apply_patches
-cp ${scriptdir}/bin/FSP/CPX-FSP-split/Fsp_M.fd projects/deltalake/blobs/Server_M.fd
-cp ${scriptdir}/bin/FSP/CPX-FSP-split/Fsp_S.fd projects/deltalake/blobs/Server_S.fd
-cp ${scriptdir}/bin/FSP/CPX-FSP-split/Fsp_T.fd projects/deltalake/blobs/Server_T.fd
 cp ${scriptdir}/bin/edk2-non-osi/Silicon/Intel/WhitleySiliconBinPkg/CpxMicrocode/mBF5065B_07002302.mcb projects/deltalake/blobs/microcode.mcb
 cp ${scriptdir}/bin/edk2-non-osi/Platform/Intel/WhitleyOpenBoardBinPkg/Ifwi/DeltaLake/FlashDescriptor.bin projects/deltalake/blobs/flashregion_0_flashdescriptor.bin
 cp ${scriptdir}/bin/edk2-non-osi/Platform/Intel/WhitleyOpenBoardBinPkg/Ifwi/DeltaLake/Me.bin projects/deltalake/blobs/flashregion_2_intel_me.bin

--- a/Wiwynn/deltalake/download_and_build.sh
+++ b/Wiwynn/deltalake/download_and_build.sh
@@ -3,7 +3,7 @@
 scriptdir="$(realpath "$(dirname "$0")")"
 osf_builder_hash="4f7836a3a8d1181fdc3444bfc1ea72b56de3e625"
 fsp_hash="0e18518131e7ecfeeb4afeab306121ca554c5054"
-edk2_non_osi_hash="eba85cf5d882340b2ce0f845facc31dde0c3dbcb"
+edk2_non_osi_hash="61662e8596dd9a64e3372f9a3ba6622d2628607c"
 
 patches="${scriptdir}/src/*.patch"
 

--- a/Wiwynn/deltalake/download_and_build.sh
+++ b/Wiwynn/deltalake/download_and_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 scriptdir="$(realpath "$(dirname "$0")")"
-osf_builder_hash="4f7836a3a8d1181fdc3444bfc1ea72b56de3e625"
+osf_builder_hash="11d894bfe70e9b371c7dba9a02c6ccb24bd0c524"
 fsp_hash="0e18518131e7ecfeeb4afeab306121ca554c5054"
 edk2_non_osi_hash="61662e8596dd9a64e3372f9a3ba6622d2628607c"
 

--- a/Wiwynn/deltalake/src/0001-Add-OCP-Delta-Lake-support.patch
+++ b/Wiwynn/deltalake/src/0001-Add-OCP-Delta-Lake-support.patch
@@ -61,7 +61,7 @@ new file mode 100644
 index 0000000..2d9fb07
 --- /dev/null
 +++ b/projects/deltalake/configs/config-deltalake.json
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,87 @@
 +{
 +  "initramfs": {
 +    "untar": [
@@ -96,14 +96,14 @@ index 0000000..2d9fb07
 +        "label": "coreboot",
 +        "url": "https://review.coreboot.org/coreboot",
 +        "branch": "master",
-+        "hash": "a8dac049b1cce95635c4e8c786af861f24eb2fb5"
++        "hash": "1df1cf994aa9ebdd9d51103d2d618f6aa66df2d6"
 +      },
 +      {
 +        "label": "vboot",
 +        "url": "https://review.coreboot.org/vboot",
 +        "dest": "3rdparty/vboot",
 +        "branch": "master",
-+        "hash": "e681c371484b50c0cc35d91123b176acdc2449eb"
++        "hash": "b827ddb9b02228fc8064d7e03bdc6f05535d5e03"
 +      }
 +    ],
 +    "files": {
@@ -123,20 +123,20 @@ index 0000000..2d9fb07
 +          "hash": "sha256:17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"
 +        },
 +        {
-+          "url": "https://ftpmirror.gnu.org/binutils/binutils-2.35.1.tar.xz",
-+          "hash": "sha256:3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607"
++          "url": "https://ftpmirror.gnu.org/binutils/binutils-2.37.tar.xz",
++          "hash": "sha256:820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
 +        },
 +        {
-+          "url": "https://ftpmirror.gnu.org/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz",
-+          "hash": "sha256:64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c"
++          "url": "https://ftpmirror.gnu.org/gcc/gcc-11.2.0/gcc-11.2.0.tar.xz",
++          "hash": "sha256:d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
 +        },
 +        {
 +          "url": "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.bz2",
 +          "hash": "sha256:3c4b8339e5ab54b1bcb2316101f8985a5da50a3f9e504d43fa6f35668bee2fd0"
 +        },
 +        {
-+          "url": "https://acpica.org/sites/acpica/files/acpica-unix2-20210331.tar.gz",
-+          "hash": "sha256:3dab326c262d4f3eaf380bbbbd7aa8c2eb5f2697f7821659222cf898d8be28c1"
++          "url": "https://acpica.org/sites/acpica/files/acpica-unix2-20220331.tar.gz",
++          "hash": "sha256:1ccda5c6a08a90b145777df635eb09f995b3472b3128f375009c5a6b01a04c7a"
 +        }
 +      ]
 +    }

--- a/Wiwynn/deltalake/src/0001-Add-OCP-Delta-Lake-support.patch
+++ b/Wiwynn/deltalake/src/0001-Add-OCP-Delta-Lake-support.patch
@@ -104,6 +104,13 @@ index 0000000..2d9fb07
 +        "dest": "3rdparty/vboot",
 +        "branch": "master",
 +        "hash": "b827ddb9b02228fc8064d7e03bdc6f05535d5e03"
++      },
++      {
++        "label": "fsp",
++        "url": "https://review.coreboot.org/fsp",
++        "dest": "3rdparty/fsp",
++        "branch": "master",
++        "hash": "13a144fd138e1c192471fe2e74416ca9a5c0e78e"
 +      }
 +    ],
 +    "files": {

--- a/Wiwynn/deltalake/src/0001-Add-OCP-Delta-Lake-support.patch
+++ b/Wiwynn/deltalake/src/0001-Add-OCP-Delta-Lake-support.patch
@@ -67,16 +67,16 @@ index 0000000..2d9fb07
 +    "untar": [
 +      {
 +        "label": "go",
-+        "url": "https://golang.org/dl/go1.16.6.linux-amd64.tar.gz",
-+        "hash": "sha256:be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
++        "url": "https://golang.org/dl/go1.17.1.linux-amd64.tar.gz",
++        "hash": "sha256:dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef"
 +      }
 +    ],
 +    "goget": [
 +      {
 +        "label": "uroot",
 +        "pkg": "https://github.com/u-root/u-root",
-+        "branch": "master",
-+        "hash": "6be1534c07b272bde925da48c2bde72ff5c69a2c"
++        "branch": "main",
++        "hash": "5476b3dd5012689338b314d850a43895ddf656c1"
 +      }
 +    ]
 +  },


### PR DESCRIPTION
There are total of 4 change requests in this pull request:

96f2fa5 Update microcode binaries for deltalake
9d3e79b Update coreboot and deps to latest stable repo picks
5916bd2 Updated u-root to latest stable release from github
eae69ef  Update FSP to latest stable hash (CedarIsland FSP 2.2.0.33)

I have tested linuxboot on DeltaLake with these changes and it works.